### PR TITLE
refactor flags again

### DIFF
--- a/main.go
+++ b/main.go
@@ -20,10 +20,12 @@ import (
 var version string
 var commit string
 
-const UNKNOWN = 3
-const CRITICAL = 2
-const WARNING = 1
-const OK = 0
+const (
+	OK = iota
+	WARNING
+	CRITICAL
+	UNKNOWN
+)
 
 const replacement = "\\n"
 
@@ -185,13 +187,8 @@ func main() {
 
 func _main() int {
 	opt := &Opt{}
-	psr := flags.NewParser(opt, flags.HelpFlag|flags.PrintErrors|flags.PassDoubleDash)
+	psr := flags.NewParser(opt, flags.HelpFlag|flags.PassDoubleDash)
 	_, err := psr.Parse()
-	if flags.WroteHelp(err) {
-		return OK
-	} else if err != nil {
-		return UNKNOWN
-	}
 	if opt.Version {
 		if commit == "" {
 			commit = "dev"
@@ -205,6 +202,12 @@ func _main() int {
 			runtime.Version(),
 			commit)
 		return OK
+	} else if flags.WroteHelp(err) {
+		fmt.Fprintf(os.Stdout, "%v\n", err)
+		return OK
+	} else if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		return UNKNOWN
 	}
 
 	if err := opt.verifyOptions(); err != nil {


### PR DESCRIPTION
### **User description**
- Not use flags.PrintErrors, display errors and help manually
- The order should be: Version, Help, and Other Errors.


___

### **PR Type**
Enhancement


___

### **Description**
- Refactor status constants using `iota` for cleaner code

- Remove `flags.PrintErrors` and handle output manually

- Reorder checks to prioritize version, help, and errors

- Print help to stdout and errors to stderr


___

### Diagram Walkthrough


```mermaid
flowchart LR
  main["main.go"] -- "refactor" --> constants["status constants"]
  main -- "remove" --> parser["flags.PrintErrors"]
  main -- "reorder" --> errors["error handling logic"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.go</strong><dd><code>Refactor constants and manual flag error handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

main.go

<ul><li>Replaced hardcoded status codes with <code>iota</code> block<br> <li> Removed <code>flags.PrintErrors</code> from parser configuration<br> <li> Reordered error checks to prioritize version and help<br> <li> Manually prints help to stdout and errors to stderr</ul>


</details>


  </td>
  <td><a href="https://github.com/monitoring-forge/check_ftp2/pull/31/files#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261">+13/-10</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

